### PR TITLE
Update to AxonFramework 4.5.5

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,0 +1,33 @@
+name: GraalVM Community Edition Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['java11']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Setup GraalVM Community Edition
+        uses: DeLaGuardo/setup-graalvm@5.0
+        with:
+          graalvm: 21.3.0
+          java: ${{ matrix.java }}
+      - name: Install Native Image
+        run: gu install native-image
+      - name: Build native image with Maven
+        working-directory: showcase-quarkus-eventsourcing
+        run: mvn verify --activate-profiles native --file pom.xml --batch-mode

--- a/showcase-quarkus-eventsourcing/README.md
+++ b/showcase-quarkus-eventsourcing/README.md
@@ -17,7 +17,7 @@
   Details see [Building a native executable](https://quarkus.io/guides/building-native-image-guide)
 * The substrate runner can be used to collect configuration data for the native image:
 ```
-$GRAALVM_HOME/bin/java -agentlib:native-image-agent=config-output-dir=native-image,caller-filter-file=native-image-caller-filter-rules.json -jar ./target/showcase-quarkus-eventsourcing-1.0-SNAPSHOT-runner.jar
+$GRAALVM_HOME/bin/java -agentlib:native-image-agent=config-output-dir=native-image,caller-filter-file=native-image-caller-filter-rules.json -jar ./target/showcase-quarkus-eventsourcing-1.3-SNAPSHOT-runner.jar
 ```
   This is helpful to get a hint on how to configure ```reflection-config.json``` and ```resources-config.json```
   These files were configured that way.
@@ -25,13 +25,13 @@ $GRAALVM_HOME/bin/java -agentlib:native-image-agent=config-output-dir=native-ima
   Ideally, there would be a axon-extension for quarkus that manages these settings.
 * The substrate runner can also be used to generate a trace of all reflection calls:
 ```
-$GRAALVM_HOME/bin/java -agentlib:native-image-agent=trace-output=native-image/trace-output.json,caller-filter-file=native-image-caller-filter-rules.json -jar ./target/showcase-quarkus-eventsourcing-1.0-SNAPSHOT-runner.jar
+$GRAALVM_HOME/bin/java -agentlib:native-image-agent=trace-output=native-image/trace-output.json,caller-filter-file=native-image-caller-filter-rules.json -jar ./target/showcase-quarkus-eventsourcing-1.3-SNAPSHOT-runner.jar
 ``` 
 * More informations abount the `native-image-agent` can be found here:
 [CONFIGURE.md](https://github.com/oracle/graal/blob/master/substratevm/CONFIGURE.md)
 
 ## Features
-* "Reactive" example using server sent events (tested with safari browser) and axon subscription query
+* "Reactive" example using server sent events (tested with safari & chrome browser) and axon subscription query
 * Replay example. Use REST DELETE ```/nicknames/projection```
 * Contains an axon upcaster example
 * Works with H2 and PostgreSql. Just switch the regarding comments in ```application.properties``` and ```persistence.xml```.
@@ -42,7 +42,7 @@ $GRAALVM_HOME/bin/java -agentlib:native-image-agent=trace-output=native-image/tr
 
 ## Notes
 * Code comments containing the marker ```Note:``` describes thoughts, background information, documented decisions and hints to problems. 
-* ```ArchitectureRulesTest``` defines rules to assure low coupling between the business core, axon and the microprofile features.
+* ```ArchitectureRulesTest``` defines rules to assure low coupling between the business core, axon and microprofile features.
 * These rules might seem a bit extreme. Some may even find them to be impractical. After all, this examples shows that it can be done.
 * This is just a simple show case, not an full application. 
 

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.joht.showcase.quarkuseventsourcing</groupId>
 	<artifactId>showcase-quarkus-eventsourcing</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.3-SNAPSHOT</version>
 
 	<properties>
     	<compiler-plugin.version>3.8.1</compiler-plugin.version>
@@ -22,7 +22,7 @@
 		<quarkus.platform.version>2.5.0.Final</quarkus.platform.version>
 		<quarkus-plugin.version>2.5.0.Final</quarkus-plugin.version>
 		
-		<axon.version>4.3.2</axon.version>
+		<axon.version>4.5.5</axon.version>
 		<dom4j.version>1.6.1</dom4j.version>
 		<xom.version>1.2.10</xom.version>
 

--- a/showcase-quarkus-eventsourcing/reflection-config.json
+++ b/showcase-quarkus-eventsourcing/reflection-config.json
@@ -219,45 +219,36 @@
 	},
 	{
 		"name": "org.axonframework.eventhandling.GapAwareTrackingToken",
-		"allDeclaredFields": true,
 		"allDeclaredMethods": true,
 		"allDeclaredConstructors": true
 	},
 	{
 		"name": "org.axonframework.eventhandling.ReplayToken",
-		"allDeclaredFields": true,
 		"allDeclaredMethods": true,
 		"allDeclaredConstructors": true
 	},
 	{
 		"name": "org.axonframework.eventhandling.TrackingToken",
-		"allDeclaredConstructors": true,
 		"allDeclaredMethods": true,
 		"allDeclaredFields": true
 	},
 	{
 		"name": "org.axonframework.eventhandling.WrappedToken",
-		"allDeclaredConstructors": true,
 		"allDeclaredMethods": true,
 		"allDeclaredFields": true
 	},
 	{
 		"name": "org.axonframework.eventhandling.Timestamp",
-		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.messaging.MetaData",
 		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.event.EventUpcaster",
-		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.SingleEntryUpcaster",
@@ -267,27 +258,20 @@
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.Upcaster",
-		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.event.EventUpcaster",
-		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.event.IntermediateEventRepresentation",
-		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.serialization.upcasting.event.SingleEventUpcaster",
 		"allDeclaredConstructors": true,
-		"allDeclaredMethods": true,
-		"allDeclaredFields": true
+		"allDeclaredMethods": true
 	},
 	{
 		"name": "org.axonframework.modelling.command.AggregateIdentifier",

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/query/boundary/QueryModelResetHandler.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/query/boundary/QueryModelResetHandler.java
@@ -6,8 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.axonframework.eventhandling.EventHandler;
-import org.axonframework.eventhandling.ResetTriggeredEvent;
+import org.axonframework.eventhandling.replay.ResetContext;
+import org.axonframework.messaging.annotation.MessageHandler;
 
 /**
  * Used to mark a method inside a event handler ("projection") to be called,
@@ -16,7 +16,7 @@ import org.axonframework.eventhandling.ResetTriggeredEvent;
 @Documented
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-@EventHandler(payloadType = ResetTriggeredEvent.class)
+@MessageHandler(messageType = ResetContext.class)
 public @interface QueryModelResetHandler {
 
 }

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/nativeimage/NatieImageReflectionConfigTest.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/nativeimage/NatieImageReflectionConfigTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  * 
  * @author JohT
  */
-class NatieImageReflectConfigTest {
+class NatieImageReflectionConfigTest {
 	private static final Jsonb create = JsonbBuilder.create();
 
 	@Test
@@ -45,7 +45,7 @@ class NatieImageReflectConfigTest {
 				// .filter(name ->
 				// !classForName(name).map(Class::isInterface).orElse(Boolean.FALSE))
 				.collect(Collectors.joining("\n"));
-		System.out.println("missingInManualEditedFile");
+		System.out.println("\nmissingInManualEditedFile:\n");
 		System.out.println(axonClasses);
 	}
 
@@ -54,7 +54,7 @@ class NatieImageReflectConfigTest {
 		Set<String> mainConfig = classNamesRegisteredForReflections("reflection-config.json");
 		Set<String> generatedConfig = classNamesRegisteredForReflections("native-image/432-reflect-config.json");
 		mainConfig.removeAll(generatedConfig);
-		System.out.println("missingInGeneratedFile");
+		System.out.println("\nmissingInGeneratedFile:\n");
 		System.out.println(mainConfig.stream().collect(Collectors.joining("\n")));
 	}
 

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/account/AccountRessourceNativeImageIT.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/account/AccountRessourceNativeImageIT.java
@@ -1,0 +1,8 @@
+package io.github.joht.showcase.quarkuseventsourcing.service.account;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class AccountRessourceNativeImageIT extends AccountResourceTest {
+	// Execute the same tests but in native mode.
+}

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NativeNicknamesProjectionManagementResourceIT.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NativeNicknamesProjectionManagementResourceIT.java
@@ -1,8 +1,0 @@
-package io.github.joht.showcase.quarkuseventsourcing.service.nickname;
-
-import io.quarkus.test.junit.NativeImageTest;
-
-@NativeImageTest
-public class NativeNicknamesProjectionManagementResourceIT extends NicknamesProjectionManagementResourceTest {
-    // run the same tests
-}

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NicknameEventStreamResourceNativeImageIT.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NicknameEventStreamResourceNativeImageIT.java
@@ -1,0 +1,8 @@
+package io.github.joht.showcase.quarkuseventsourcing.service.nickname;
+
+import io.quarkus.test.junit.NativeImageTest;
+
+@NativeImageTest
+public class NicknameEventStreamResourceNativeImageIT extends NicknameEventStreamResourceTest {
+	// Execute the same tests but in native mode.
+}

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NicknamesProjectionManagementResourceNativeImageIT.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/nickname/NicknamesProjectionManagementResourceNativeImageIT.java
@@ -3,7 +3,6 @@ package io.github.joht.showcase.quarkuseventsourcing.service.nickname;
 import io.quarkus.test.junit.NativeImageTest;
 
 @NativeImageTest
-public class NativeNicknameEventStreamResourceIT extends NicknameEventStreamResourceTest {
-
+public class NicknamesProjectionManagementResourceNativeImageIT extends NicknamesProjectionManagementResourceTest {
     // Execute the same tests but in native mode.
 }


### PR DESCRIPTION
- Updated axon version from 4.3.2 to 4.5.5
- QueryModelResetHandler updated to reflect the changes in the original  annotation: https://github.com/AxonFramework/AxonFramework/commit/7b8a1862f711e2093751fc81a37c16599789dac2
- Unified native image integration tests
- Continuous Integration for native image build with integration tests
- Deleted unnecessary reflection configurations within `reflection-config.json`