### PR TITLE
Switch from H2 to PostgreSQL database using quarkus.profile

### DIFF
--- a/showcase-quarkus-eventsourcing/README.md
+++ b/showcase-quarkus-eventsourcing/README.md
@@ -1,14 +1,24 @@
 # Showcase for Event Sourcing on Quarkus using AxonFramework and MicroProfile
 
-## Getting started
+## Getting started with H2 database
 * Clone or download this repository. 
 * Open a terminal/command window.
-* Locate the h2 jar in your maven repository, e.g. `repository/com/h2database/h2/1.4.197/`.
-* Start the h2 database server using `java -cp h2-1.4.197.jar org.h2.tools.Server -tcp -tcpAllowOthers`.
+* Locate the h2 jar in your maven repository, e.g.: `repository/com/h2database/h2/1.4.197/`
+* Start the h2 database server using: `java -cp h2-1.4.197.jar org.h2.tools.Server -tcp -tcpAllowOthers`
 * Without the h2 command argument `-tcp` the web console will be opened in the browser. Since the application uses the default user it won't work properly when the same user is logged in on the web console.
 * Open another terminal/command window. Don't close the one where the h2 server is running.
 * Open the directory where this README.md is located.
-* Run the application by using the following command: ```mvn compile quarkus:dev```.
+* Run the application by using the following command: `mvn compile quarkus:dev`
+* Open the UI [http://localhost:8080](http://localhost:8080)
+* (Optional) Use the postman collection "showcase-quarkus-eventsourcing.postman_collection.json" for service call examples.
+* (Optional) Use the unit tests inside the service package to replay nicknames, create new ones or create further accounts.
+
+## Getting started with PostgreSQL database
+* Clone or download this repository. 
+* Open a terminal/command window.
+* Start PostgreSql database with (default) name "postgres" on port 5432. Details see [application.properties](./src/main/resources/application.properties).
+* Open the directory where this README.md is located.
+* Run the application by using the following command: `mvn compile quarkus:dev -Dquarkus.profile=postgres`
 * Open the UI [http://localhost:8080](http://localhost:8080)
 * (Optional) Use the postman collection "showcase-quarkus-eventsourcing.postman_collection.json" for service call examples.
 * (Optional) Use the unit tests inside the service package to replay nicknames, create new ones or create further accounts.

--- a/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/reflect-config.json
+++ b/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/reflect-config.json
@@ -1,5 +1,44 @@
 [
 {
+  "name":"com.github.benmanes.caffeine.cache.BLCHeader$DrainStatusRef",
+  "fields":[{"name":"drainStatus"}]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueColdProducerFields",
+  "fields":[{"name":"producerLimit"}]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueConsumerFields",
+  "fields":[{"name":"consumerIndex"}]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.BaseMpscLinkedArrayQueueProducerFields",
+  "fields":[{"name":"producerIndex"}]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.PS",
+  "fields":[
+    {"name":"key"}, 
+    {"name":"value"}
+  ]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.PSW",
+  "fields":[{"name":"writeTime"}]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.PSWMS",
+  "methods":[{"name":"<init>","parameterTypes":[] }]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.SSMSA",
+  "methods":[{"name":"<init>","parameterTypes":["com.github.benmanes.caffeine.cache.Caffeine","com.github.benmanes.caffeine.cache.CacheLoader","boolean"] }]}
+,
+{
+  "name":"com.github.benmanes.caffeine.cache.StripedBuffer",
+  "fields":[{"name":"tableBusy"}]}
+,
+{
   "name":"io.github.joht.showcase.quarkuseventsourcing.domain.model.account.AccountAggregate",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -188,6 +227,10 @@
   "queriedMethods":[{"name":"toString","parameterTypes":[] }]}
 ,
 {
+  "name":"java.lang.Thread",
+  "fields":[{"name":"threadLocalRandomProbe"}]}
+,
+{
   "name":"java.security.SecureRandomParameters"}
 ,
 {
@@ -273,7 +316,7 @@
   "queryAllDeclaredMethods":true}
 ,
 {
-  "name":"org.axonframework.config.DefaultConfigurer$$Lambda$583/0x0000000840557040",
+  "name":"org.axonframework.config.DefaultConfigurer$$Lambda$588/0x0000000840569440",
   "queryAllDeclaredMethods":true}
 ,
 {
@@ -285,7 +328,7 @@
   ]}
 ,
 {
-  "name":"org.axonframework.config.MessageMonitorFactoryBuilder$$Lambda$633/0x000000084056cc40",
+  "name":"org.axonframework.config.MessageMonitorFactoryBuilder$$Lambda$638/0x0000000840579840",
   "queryAllDeclaredMethods":true}
 ,
 {
@@ -624,6 +667,10 @@
 ,
 {
   "name":"org.slf4j.spi.SLF4JServiceProvider"}
+,
+{
+  "name":"sun.misc.Unsafe",
+  "fields":[{"name":"theUnsafe"}]}
 ,
 {
   "name":"sun.security.provider.SHA",

--- a/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/reflect-config.json
+++ b/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/reflect-config.json
@@ -316,7 +316,7 @@
   "queryAllDeclaredMethods":true}
 ,
 {
-  "name":"org.axonframework.config.DefaultConfigurer$$Lambda$588/0x0000000840569440",
+  "name":"org.axonframework.config.DefaultConfigurer$$Lambda$588/0x0000000840568440",
   "queryAllDeclaredMethods":true}
 ,
 {
@@ -328,7 +328,7 @@
   ]}
 ,
 {
-  "name":"org.axonframework.config.MessageMonitorFactoryBuilder$$Lambda$638/0x0000000840579840",
+  "name":"org.axonframework.config.MessageMonitorFactoryBuilder$$Lambda$638/0x0000000840586040",
   "queryAllDeclaredMethods":true}
 ,
 {

--- a/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/resource-config.json
+++ b/showcase-quarkus-eventsourcing/native-image-agent-results/java11-axon-4-5-5-quarkus-2-6-1-Final/resource-config.json
@@ -38,6 +38,9 @@
       "pattern":"\\QMETA-INF/services/javax.json.spi.JsonProvider\\E"
     }, 
     {
+      "pattern":"\\QMETA-INF/services/javax.validation.spi.ValidationProvider\\E"
+    }, 
+    {
       "pattern":"\\QMETA-INF/services/javax.xml.stream.XMLInputFactory\\E"
     }, 
     {
@@ -89,10 +92,10 @@
       "pattern":"\\Qdb/command/common/V1.0.0__AxonOnMicroprofileTryoutEventsourcing.sql\\E"
     }, 
     {
-      "pattern":"\\Qdb/command/common/V1.0.2__DomainEventEntryTypeNullable.sql\\E"
+      "pattern":"\\Qdb/command/h2/V1.0.1__H2BlobTypeForBinaryData.sql\\E"
     }, 
     {
-      "pattern":"\\Qdb/command/h2/V1.0.1__H2BlobTypeForBinaryData.sql\\E"
+      "pattern":"\\Qdb/command/h2/V1.0.2__H2DomainEventEntryTypeNullable.sql\\E"
     }, 
     {
       "pattern":"\\Qdb/query/common/V1.1.0__AxonOnMicroprofileTryoutTrackingToken.sql\\E"

--- a/showcase-quarkus-eventsourcing/src/main/resources/META-INF/persistence.xml.reference
+++ b/showcase-quarkus-eventsourcing/src/main/resources/META-INF/persistence.xml.reference
@@ -2,6 +2,10 @@
 <persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
 
+	<!-- (2022-01) Persistence unit configuration moved into "application.properties". -->
+	<!-- "application.properties" support profiles that make it possible to switch between h2 and postgres configuration using a build property.-->
+	<!-- "application.properties" are quarkus specific and dont meet MicroProfile Standard. -->
+	<!-- This file is kept for reference to setup an AxonFramework application for another MicroProfile server like WildFly -->
 	<persistence-unit name="query.model" transaction-type="JTA">
 		<exclude-unlisted-classes>false</exclude-unlisted-classes>
 		<properties>

--- a/showcase-quarkus-eventsourcing/src/main/resources/application.properties
+++ b/showcase-quarkus-eventsourcing/src/main/resources/application.properties
@@ -22,25 +22,12 @@ quarkus.flyway.schemas=axon_on_microprofile_tryout,axon_on_microprofile_query_tr
 quarkus.flyway.table=flyway_history
 
 # Flyway database setup locations (supporting database and command/query specific setups)
-#   PostgreSql as database for the command- and query-side:
-#quarkus.flyway.locations=db/command/common,db/command/postgresql,db/query/common,db/query/postgresql
 #   H2 as database for the command- and query-side:
 quarkus.flyway.locations=db/command/common,db/command/h2,db/query/common,db/query/h2
+#   PostgreSql as database for the command- and query-side (for quarkus.profile=postges):
+%postgres.quarkus.flyway.locations=db/command/common,db/command/postgresql,db/query/common,db/query/postgresql
 #   PostgreSql as database for the command-side and H2 as database for the query-side:
 #quarkus.flyway.locations=db/command/common,db/command/postgresql,db/query/common,db/query/h2
-
-# -------------
-# --> Please also consider "persistence.xml" for database setting changes
-# -------------
-
-# PostgreSql as default database e.g. for flyway
-#quarkus.datasource.db-kind=postgresql
-#quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
-#quarkus.datasource.username=postgres
-#quarkus.datasource.password=
-#quarkus.datasource.max-size=8
-#quarkus.datasource.min-size=2
-#quarkus.datasource.transactions=xa
 
 # H2 in-memory as default database e.g. for flyway
 quarkus.datasource.db-kind=h2
@@ -51,14 +38,14 @@ quarkus.datasource.min-size=2
 quarkus.datasource.max-size=8
 quarkus.datasource.transactions=xa
 
-# PostgreSql as messaging database
-#quarkus.datasource.messaging.db-kind=postgresql
-#quarkus.datasource.messaging.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
-#quarkus.datasource.messaging.username=postgres
-#quarkus.datasource.messaging.password=
-#quarkus.datasource.messaging.min-size=2
-#quarkus.datasource.messaging.max-size=8
-#quarkus.datasource.messaging.transactions=xa
+# PostgreSql as default database e.g. for flyway (for quarkus.profile=postges)
+%postgres.quarkus.datasource.db-kind=postgresql
+%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
+%postgres.quarkus.datasource.username=postgres
+%postgres.quarkus.datasource.password=
+%postgres.quarkus.datasource.max-size=8
+%postgres.quarkus.datasource.min-size=2
+%postgres.quarkus.datasource.transactions=xa
 
 # H2 in-memory as messaging database 
 quarkus.datasource.messaging.db-kind=h2
@@ -68,6 +55,30 @@ quarkus.datasource.messaging.password=sa
 quarkus.datasource.messaging.min-size=2
 quarkus.datasource.messaging.max-size=8
 quarkus.datasource.messaging.transactions=xa
+
+# PostgreSql as messaging database (for quarkus.profile=postges)
+%postgres.quarkus.datasource.messaging.db-kind=postgresql
+%postgres.quarkus.datasource.messaging.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
+%postgres.quarkus.datasource.messaging.username=postgres
+%postgres.quarkus.datasource.messaging.password=
+%postgres.quarkus.datasource.messaging.min-size=2
+%postgres.quarkus.datasource.messaging.max-size=8
+%postgres.quarkus.datasource.messaging.transactions=xa
+
+# ----------------------------------------------
+# Persistence Unit Configuration
+# -------------
+# (2022-01) "persistence.xml.reference" contains the former "persistence.xml" configuration that is now located here.
+# The drawback is, that this is Quarkus specific. Running the application on another MicroProfile compliant server
+# like WildFly would need the ""persistence.xml" to be restored again.
+# The advantage is, that quarkus configuration profiles can be used here which makes it possible to
+# switch between H2 and PostgreSQL using a build property without the need to (un-)comment code in different files manually.
+# -------------
+quarkus.hibernate-orm."query.model".datasource=messaging
+quarkus.hibernate-orm."query.model".packages=io.github.joht.showcase.quarkuseventsourcing.query.model
+#quarkus.hibernate-orm."query.model".validate-in-dev-mode=false
+quarkus.hibernate-orm."query.model"dialect=org.hibernate.dialect.H2Dialect
+%postgres.quarkus.hibernate-orm."query.model"dialect=org.hibernate.dialect.PostgreSQL95Dialect
 
 # Quarkus supports CORS directly.
 # To not depend directly upon quarkus, standard microprofile config is used

--- a/showcase-quarkus-eventsourcing/src/main/resources/application.properties
+++ b/showcase-quarkus-eventsourcing/src/main/resources/application.properties
@@ -76,7 +76,7 @@ quarkus.datasource.messaging.transactions=xa
 # -------------
 quarkus.hibernate-orm."query.model".datasource=messaging
 quarkus.hibernate-orm."query.model".packages=io.github.joht.showcase.quarkuseventsourcing.query.model
-#quarkus.hibernate-orm."query.model".validate-in-dev-mode=false
+quarkus.hibernate-orm."query.model".validate-in-dev-mode=false
 quarkus.hibernate-orm."query.model"dialect=org.hibernate.dialect.H2Dialect
 %postgres.quarkus.hibernate-orm."query.model"dialect=org.hibernate.dialect.PostgreSQL95Dialect
 

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/command/common/V1.0.2__DomainEventEntryTypeNullable.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/command/common/V1.0.2__DomainEventEntryTypeNullable.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "axon_on_microprofile_tryout"."domainevententry" ALTER COLUMN "TYPE" SET NULL;

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/command/h2/V1.0.2__H2DomainEventEntryTypeNullable.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/command/h2/V1.0.2__H2DomainEventEntryTypeNullable.sql
@@ -1,0 +1,2 @@
+-- Removing "NOT NULL" on a column is done using "SET NULL" for H2 databases:
+ALTER TABLE "axon_on_microprofile_tryout"."domainevententry" ALTER COLUMN TYPE SET NULL;

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/command/postgresql/V1.0.2__PostgreSqlDomainEventEntryTypeNullable.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/command/postgresql/V1.0.2__PostgreSqlDomainEventEntryTypeNullable.sql
@@ -1,0 +1,2 @@
+-- Removing "NOT NULL" on a column is done using "DROP NOT NULL" for PostgreSQL databases:
+ALTER TABLE "axon_on_microprofile_tryout"."domainevententry" ALTER COLUMN TYPE DROP NOT NULL;


### PR DESCRIPTION
Use [Quarkus Configuration Profiles](https://quarkus.io/guides/config-reference#profiles) to switch between H2 (default) and PostgreSQL database instead of (un-)commenting configuration entries manually. 

Start the application in development mode with a PostgreSQL database:
```shell
mvn compile quarkus:dev -Dquarkus.profile=postgres
```

Start the application in development mode with a (default) H2 database:
```shell
mvn compile quarkus:dev -Dquarkus.profile=postgres
```

This pull request also resolves an issue with PostgreSQL database setup introduced by [commit 7f184cf](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/32/commits/7f184cf5aa4651b1b4b4ea27001d5e4b19971f8f)