### PR TITLE
Auto commit native image reports only on push

### DIFF
--- a/.github/workflows/native-image-agent.yml
+++ b/.github/workflows/native-image-agent.yml
@@ -3,7 +3,13 @@ name: GraalVM Community Edition native-image-agent
 on:
   workflow_call:
     inputs:
-      auto-commit-message:
+      ci-commit-message:
+        required: true
+        type: string    
+      ci-commit-author:
+        required: true
+        type: string    
+      original-event-name:
         required: true
         type: string    
     secrets:
@@ -17,68 +23,56 @@ jobs:
     strategy:
       matrix:
         java: ['java11']
-    #env:
-    #  AUTO_COMMIT_MESSAGE: Automated native image agent results (CI)
     steps:
+      - name: Display Inputs
+        env:
+          INPUTS_JSON: ${{ toJson(inputs) }}
+        run: echo "$INPUTS_JSON"
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.git-push-access-token }}
-      - name: Set the environment variable "commit-message"
-        run: echo "commit-message=$(git log -1 --pretty=format:"%s")" >> $GITHUB_ENV
       - uses: actions/cache@v2
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Setup GraalVM Community Edition
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         uses: DeLaGuardo/setup-graalvm@5.0
         with:
           graalvm: 21.3.0
           java: ${{ matrix.java }}
       - name: Install Native Image Tool for GraalVM
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         run: gu install native-image
         
       - name: Run application on GraalVM with activated native-image-agent for trace file generation and execute its integrations tests
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: mvn verify --activate-profiles native-image-agent-trace --file pom.xml --batch-mode  && sleep 4
       - name: Generate configuration json files out of the native-image-agent trace output
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: $GRAALVM_HOME/bin/native-image-configure generate --trace-input=target/native-image-agent-trace.json --output-dir=target/native-image-agent-trace-configs --caller-filter-file=native-image-caller-filter-rules.json
       
       - name: Get the axon version from the maven pom variable and set the environment variable "axon-version"
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: echo "axon-version=$(mvn -q help:evaluate -Dexpression=axon.version -DforceStdout | tr . -)" >> $GITHUB_ENV
       - name: Get the quarkus version from the maven pom variable and set the environment variable "quarkus-version"
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: echo "quarkus-version=$(mvn -q help:evaluate -Dexpression=quarkus.platform.version -DforceStdout | tr . -)" >> $GITHUB_ENV
       - name: Assemble the name of the directory for the native image agent output files and set the environment variable "native-image-agent-results-directory"
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         run: echo "native-image-agent-results-directory=native-image-agent-results/${{ matrix.java }}-axon-${{ env.axon-version }}-quarkus-${{ env.quarkus-version }}" >> $GITHUB_ENV
       
       - name: Create the native image agent results directory
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: mkdir -p ${{ env.native-image-agent-results-directory }}
       - name: Copy the native image agent trace file into the native image agent results directory
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: cp target/native-image-agent-trace.json ${{ env.native-image-agent-results-directory }}
       - name: Copy the native image agent configuration files into the native image agent results directory
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         working-directory: showcase-quarkus-eventsourcing
         run: cp target/native-image-agent-trace-configs/* ${{ env.native-image-agent-results-directory }}
       
       - name: Archive native image agent results
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
         uses: actions/upload-artifact@v2
         with:
           name: native-image-agent-results-${{ matrix.java }}
@@ -87,11 +81,11 @@ jobs:
       
       - name: Commit native image agent results
         working-directory: showcase-quarkus-eventsourcing
-        # Don't run again on results auto commit and don't run on forks
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE && github.event.pull_request.head.repo.full_name == github.repository
+        # Don't run again on already pushed continuous integration auto commit. Don't run on pull request events.
+        if: inputs.original-event-name != 'pull_request'
         run: |
-          git config --global user.name 'Showcase Pipeline'
+          git config --global user.name '${{ inputs.ci-commit-author }}'
           git config --global user.email 'joht@users.noreply.github.com'
           git add ${{ env.native-image-agent-results-directory }}
-          git commit -m "${{ inputs.auto-commit-message }}"
+          git commit -m "${{ inputs.ci-commit-message }}"
           git push

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -25,25 +25,53 @@ jobs:
       matrix:
         java: ['java11']
     env: 
-      AUTO_COMMIT_MESSAGE: Automated native image agent results (CI)
+      CI_COMMIT_MESSAGE: Automated native image agent results (CI)
+      CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} Continuous Integration
     outputs:
-      commit-message: ${{ steps.commit-message-output.outputs.commit-message }}
-      auto-commit-message: ${{ steps.auto-commit-message-output.outputs.auto-commit-message }}
+      ci-commit-message: ${{ steps.ci-commit-message-output.outputs.ci-commit-message }}
+      ci-commit-author: ${{ steps.ci-commit-author-output.outputs.ci-commit-author }}
+      is-ci-commit: ${{ steps.is-ci-commit-output.outputs.is-ci-commit }}
+      original-event-name: ${{ steps.original-event-name-output.outputs.original-event-name }}
     steps:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Set the environment variable "commit-message"
+      - name: Set environment variable "commit-message"
         run: echo "commit-message=$(git log -1 --pretty=format:"%s")" >> $GITHUB_ENV
-      - name: Set commit message output parameter
-        id: commit-message-output
-        run: echo "::set-output name=commit-message::${{ env.commit-message }}"
-      - name: Set auto commit message output parameter
-        id: auto-commit-message-output
-        run: echo "::set-output name=auto-commit-message::${{ env.AUTO_COMMIT_MESSAGE }}"
+      - name: Display environment variable "commit-message"
+        run: echo "commit-message=${{ env.commit-message }}"
+
+      - name: Set environment variable "commit-author"
+        run: echo "commit-author=$(git log -1 --pretty=format:'%an')" >> $GITHUB_ENV
+      - name: Display environment variable "commit-author"
+        run: echo "commit-author=${{ env.commit-author }}"
+
+      # Detect if the current commit was automatically pushed by continuous integration
+      - name: Set environment variable "is-ci-commit"
+        if: env.commit-message == env.CI_COMMIT_MESSAGE && env.commit-author == env.CI_COMMIT_AUTHOR
+        run: echo "is-ci-commit=true" >> $GITHUB_ENV
+      - name: Display environment variable "is-ci-commit"
+        run: echo "is-ci-commit=${{ env.is-ci-commit }}"
+      - name: Info message on CI auto commit 
+        if: env.is-ci-commit
+        run: echo "Continuous Integration Auto Commit - The following steps will be skipped"
+      
+      # Set job output parameter values
+      - name: Set output parameter "ci-commit-message"
+        id: ci-commit-message-output
+        run: echo "::set-output name=ci-commit-message::${{ env.CI_COMMIT_MESSAGE }}"
+      - name: Set output parameter "ci-commit-author"
+        id: ci-commit-author-output
+        run: echo "::set-output name=ci-commit-author::${{ env.CI_COMMIT_AUTHOR }}"
+      - name: Set output parameter "is-ci-commit"
+        id: is-ci-commit-output
+        run: echo "::set-output name=is-ci-commit::${{ env.is-ci-commit }}"
+      - name: Set output parameter "original-event-name"
+        id: original-event-name-output
+        run: echo "::set-output name=original-event-name::${{ github.event_name }}"
       
       - uses: actions/cache@v2
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
+        if: env.is-ci-commit == false
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -51,17 +79,17 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Setup GraalVM Community Edition
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
+        if: env.is-ci-commit == false
         uses: DeLaGuardo/setup-graalvm@5.0
         with:
           graalvm: 21.3.0
           java: ${{ matrix.java }}
       - name: Install Native Image
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
+        if: env.is-ci-commit == false
         run: gu install native-image
 
       - name: Build native image with Maven
-        if: env.commit-message != env.AUTO_COMMIT_MESSAGE
+        if: env.is-ci-commit == false
         working-directory: showcase-quarkus-eventsourcing
         run: mvn verify --activate-profiles native --file pom.xml --batch-mode
 
@@ -70,9 +98,11 @@ jobs:
     #Variables are not yet supported for "uses". Workaround are hardcoded git refs. TODO: Change to main/master branch as soon as merged.
     #https://stackoverflow.com/questions/69737232/github-context-variables-not-evaluating-for-reusable-workflow-reference
     #uses: JohT/showcase-quarkus-eventsourcing/.github/workflows/native-image-agent.yml@${{github.event.pull_request.head.ref}}
-    uses: JohT/showcase-quarkus-eventsourcing/.github/workflows/native-image-agent.yml@master
-    if: needs.native-image-build.outputs.commit-message != needs.native-image-build.outputs.auto-commit-message
+    uses: JohT/showcase-quarkus-eventsourcing/.github/workflows/native-image-agent.yml@feature/auto-commit-on-push
+    if: needs.native-image-build.outputs.is-ci-commit == false
     with: 
-      auto-commit-message: ${{ needs.native-image-build.outputs.auto-commit-message }}    
+      ci-commit-message: ${{ needs.native-image-build.outputs.ci-commit-message }}
+      ci-commit-author: ${{ needs.native-image-build.outputs.ci-commit-author }}
+      original-event-name: ${{ needs.native-image-build.outputs.original-event-name }}
     secrets:
       git-push-access-token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}


### PR DESCRIPTION
The automatically pushed native image agent results introduced in #28 should not be triggered on every pull request event but only when the changes are pushed to the main (master) branch. 

The auto commit is currently only identified by its commit message. This should be extended to the commit author in case the same message is used coincidently.