### PR TITLE
Migrate to H2 version 2.1, Automate PostgreSQL build and test, Update Code Coverage

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -49,3 +49,8 @@ jobs:
       - name: Build with Maven, Test with PostgreSql
         working-directory: showcase-quarkus-eventsourcing
         run: mvn verify -Dquarkus.profile=postgres --file pom.xml --batch-mode
+        env:
+          # The hostname used to communicate with the PostgreSQL service container
+          POSTGRES_HOST: postgres
+          # The default PostgreSQL port
+          POSTGRES_PORT: 5432

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -1,0 +1,51 @@
+name: Java Continuous Integration (PostgreSQL)
+
+on:
+  push:
+    branches:
+      - master
+    # Ignore changes in documentation and reports
+    paths-ignore: 
+      - 'showcase-quarkus-eventsourcing/native-image-agent-results/**'
+      - '**/*.md'
+      - '**/*.txt'
+  pull_request:
+    branches:
+      - master
+    # Ignore changes in documentation and reports
+    paths-ignore: 
+      - 'showcase-quarkus-eventsourcing/native-image-agent-results/**'
+      - '**/*.md'
+      - '**/*.txt'
+
+jobs:
+  # Label of the container job
+  postgresql-build:
+    # Containers must run in Linux based operating systems
+    runs-on: ubuntu-latest
+    # Docker Hub image that `postgresql-build` executes in
+    container: maven:3.8.5-openjdk-18
+
+    # Service containers to run with `postgresql-build`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Build with Maven, Test with PostgreSql
+        working-directory: showcase-quarkus-eventsourcing
+        run: mvn verify -Dquarkus.profile=postgres --file pom.xml --batch-mode

--- a/showcase-quarkus-eventsourcing/README.md
+++ b/showcase-quarkus-eventsourcing/README.md
@@ -4,7 +4,7 @@
 * Clone or download this repository. 
 * Open a terminal/command window.
 * Locate the h2 jar in your maven repository, e.g.: `repository/com/h2database/h2/1.4.197/`
-* Start the h2 database server using: `java -cp h2-1.4.197.jar org.h2.tools.Server -tcp -tcpAllowOthers`
+* Start the h2 database server using: `java -cp h2-1.4.197.jar org.h2.tools.Server -tcp -tcpAllowOthers -ifNotExists`
 * Without the h2 command argument `-tcp` the web console will be opened in the browser. Since the application uses the default user it won't work properly when the same user is logged in on the web console.
 * Open another terminal/command window. Don't close the one where the h2 server is running.
 * Open the directory where this README.md is located.

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -19,6 +19,8 @@
 		<failsafe-plugin.version>2.22.2</failsafe-plugin.version>
 		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 		<jasmine-maven-plugin.version>2.2</jasmine-maven-plugin.version>
+		<phantomjs-maven-plugin.version>0.7</phantomjs-maven-plugin.version>
+		<phantomjs.version>2.1.1</phantomjs.version>
 
    		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     	<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -227,9 +229,26 @@
 	<build>
 		<plugins>
 			<plugin>
+				<!-- phantomjs-maven-plugin provides a distinct phantomjs version for jasmine-maven-plugin -->
+				<!-- This is done here to get a "newer" version of phantomjs. -->
+     			<groupId>com.github.klieber</groupId>
+      			<artifactId>phantomjs-maven-plugin</artifactId>
+      			<version>${phantomjs-maven-plugin.version}</version>
+      			<executions>
+        			<execution>
+          				<goals>
+            				<goal>install</goal>
+          				</goals>
+        			</execution>
+      			</executions>
+      			<configuration>
+        			<version>${phantomjs.version}</version>
+      			</configuration>
+    		</plugin>
+			<plugin>
 				<groupId>com.github.searls</groupId>
 				<artifactId>jasmine-maven-plugin</artifactId>
-				<version>2.2</version>
+				<version>${jasmine-maven-plugin.version}</version>
 				<!-- Run Jasmine JavaScript Unit-Tests -->
 				<executions>
 					<execution>
@@ -237,6 +256,17 @@
 							<goal>bdd</goal>
 							<goal>test</goal>
 						</goals>
+						<!-- The configuration is not necessary in most cases, since phantomjs will be downloaded automatically. -->
+						<!-- It is only needed when phantomjs is provided explicitly. -->
+						<configuration>
+            				<webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
+            				<webDriverCapabilities>
+              				<capability>
+                				<name>phantomjs.binary.path</name>
+                				<value>${phantomjs.binary}</value>
+              				</capability>
+            				</webDriverCapabilities>
+          				</configuration>
 					</execution>
 				</executions>
 				<configuration>

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -22,8 +22,8 @@
 
    		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     	<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-		<quarkus.platform.version>2.8.3.Final</quarkus.platform.version>
-		<quarkus.plugin.version>2.9.0.Final</quarkus.plugin.version>
+		<quarkus.platform.version>2.9.1.Final</quarkus.platform.version>
+		<quarkus.plugin.version>2.9.1.Final</quarkus.plugin.version>
 		
 		<axon.version>4.5.9</axon.version>
 		<dom4j.version>1.6.1</dom4j.version>

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -17,7 +17,7 @@
 		
 		<surefire-plugin.version>2.22.2</surefire-plugin.version>
 		<failsafe-plugin.version>2.22.2</failsafe-plugin.version>
-		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
 		<jasmine-maven-plugin.version>2.2</jasmine-maven-plugin.version>
 
    		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
@@ -389,7 +389,7 @@
 						<goals>
 							<goal>check</goal>
 						</goals>
-						<phase>test</phase>
+						 <phase>post-integration-test</phase>
 						<configuration>
 							<dataFile>${project.build.directory}/jacoco-quarkus.exec</dataFile>
 							<rules>

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
@@ -209,8 +209,8 @@ public class AxonConfiguration {
 
     private EventStorageEngine eventStorageEngine(Configuration config) {
         EventSchema schema = EventSchema.builder()
-                .eventTable(DATABASE_SCHEMA_COMMAND_SIDE + "." + DATABASE_TABLE_DOMAIN_EVENTS)
-                .snapshotTable(DATABASE_SCHEMA_COMMAND_SIDE + "." + DATABASE_TABLE_SNAPSHOTS)
+                .eventTable("\"" + DATABASE_SCHEMA_COMMAND_SIDE + "\".\"" + DATABASE_TABLE_DOMAIN_EVENTS + "\"")
+                .snapshotTable("\"" + DATABASE_SCHEMA_COMMAND_SIDE + "\".\"" + DATABASE_TABLE_SNAPSHOTS + "\"")
                 .timestampColumn("eventtimestamp")
                 .build();
         return JdbcEventStorageEngine.builder()
@@ -278,7 +278,7 @@ public class AxonConfiguration {
     // Note Query-Side
     private JdbcTokenStore jdbcTokenStore(Configuration config) {
 		TokenSchema schema = TokenSchema.builder()
-				.setTokenTable(DATABASE_SCHEMA_QUERY_SIDE + "." + DATABASE_TABLE_TOKEN)
+				.setTokenTable("\"" + DATABASE_SCHEMA_QUERY_SIDE + "\".\"" + DATABASE_TABLE_TOKEN + "\"")
 				.setTimestampColumn("eventtimestamp").build();
         return JdbcTokenStore.builder()
                 .connectionProvider(this::getConnection)

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
@@ -211,6 +211,7 @@ public class AxonConfiguration {
         EventSchema schema = EventSchema.builder()
                 .eventTable(DATABASE_SCHEMA_COMMAND_SIDE + "." + DATABASE_TABLE_DOMAIN_EVENTS)
                 .snapshotTable(DATABASE_SCHEMA_COMMAND_SIDE + "." + DATABASE_TABLE_SNAPSHOTS)
+                .timestampColumn("eventtimestamp")
                 .build();
         return JdbcEventStorageEngine.builder()
                 .schema(schema)
@@ -276,7 +277,9 @@ public class AxonConfiguration {
 
     // Note Query-Side
     private JdbcTokenStore jdbcTokenStore(Configuration config) {
-        TokenSchema schema = TokenSchema.builder().setTokenTable(DATABASE_SCHEMA_QUERY_SIDE + "." + DATABASE_TABLE_TOKEN).build();
+		TokenSchema schema = TokenSchema.builder()
+				.setTokenTable(DATABASE_SCHEMA_QUERY_SIDE + "." + DATABASE_TABLE_TOKEN)
+				.setTimestampColumn("eventtimestamp").build();
         return JdbcTokenStore.builder()
                 .connectionProvider(this::getConnection)
                 .contentType(isPostgreSqlDatabaseUsingJsonbForBinaryDataOnQuerySide() ? postgreSqlObjectType() : byte[].class)

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
@@ -211,7 +211,16 @@ public class AxonConfiguration {
         EventSchema schema = EventSchema.builder()
                 .eventTable("\"" + DATABASE_SCHEMA_COMMAND_SIDE + "\".\"" + DATABASE_TABLE_DOMAIN_EVENTS + "\"")
                 .snapshotTable("\"" + DATABASE_SCHEMA_COMMAND_SIDE + "\".\"" + DATABASE_TABLE_SNAPSHOTS + "\"")
-                .timestampColumn("eventtimestamp")
+                .aggregateIdentifierColumn("AGGREGATEIDENTIFIER")
+                .eventIdentifierColumn("EVENTIDENTIFIER")
+                .globalIndexColumn("GLOBALINDEX")
+                .metaDataColumn("METADATA")
+                .payloadColumn("PAYLOAD")
+                .payloadTypeColumn("PAYLOADTYPE")
+                .payloadRevisionColumn("PAYLOADREVISION")
+                .sequenceNumberColumn("SEQUENCENUMBER")
+                .timestampColumn("EVENTTIMESTAMP") // needed to be changed since TIMESTAMP is a reserved word
+                .typeColumn("TYPE")
                 .build();
         return JdbcEventStorageEngine.builder()
                 .schema(schema)
@@ -279,7 +288,13 @@ public class AxonConfiguration {
     private JdbcTokenStore jdbcTokenStore(Configuration config) {
 		TokenSchema schema = TokenSchema.builder()
 				.setTokenTable("\"" + DATABASE_SCHEMA_QUERY_SIDE + "\".\"" + DATABASE_TABLE_TOKEN + "\"")
-				.setTimestampColumn("eventtimestamp").build();
+				.setOwnerColumn("OWNER")
+				.setProcessorNameColumn("PROCESSORNAME")
+				.setSegmentColumn("SEGMENT")
+				.setTimestampColumn("EVENTTIMESTAMP")
+				.setTokenColumn("TOKEN")
+				.setTokenTypeColumn("TOKENTYPE")
+				.build();
         return JdbcTokenStore.builder()
                 .connectionProvider(this::getConnection)
                 .contentType(isPostgreSqlDatabaseUsingJsonbForBinaryDataOnQuerySide() ? postgreSqlObjectType() : byte[].class)

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/query/model/account/AccountEntity.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/query/model/account/AccountEntity.java
@@ -10,7 +10,7 @@ import javax.persistence.Table;
 import io.github.joht.showcase.quarkuseventsourcing.message.common.Nickname;
 
 @Entity
-@Table(name = "account", schema = "axon_on_microprofile_query_tryout")
+@Table(name = "\"account\"", schema = "\"axon_on_microprofile_query_tryout\"")
 public class AccountEntity {
 
 	@EmbeddedId

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/query/model/nickname/NicknameEntity.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/query/model/nickname/NicknameEntity.java
@@ -15,7 +15,7 @@ import io.github.joht.showcase.quarkuseventsourcing.message.common.Nickname;
 import io.github.joht.showcase.quarkuseventsourcing.message.query.nickname.NicknameDetails;
 
 @Entity
-@Table(name = "nickname", schema = "axon_on_microprofile_query_tryout")
+@Table(name = "\"nickname\"", schema = "\"axon_on_microprofile_query_tryout\"")
 @NamedQueries({
         @NamedQuery(name = NicknameEntity.QUERY_NICKNAMES, query = " SELECT nickname FROM NicknameEntity nickname "
                 + "WHERE nickname.key.nickname LIKE :partOfNickname "

--- a/showcase-quarkus-eventsourcing/src/main/resources/application.properties
+++ b/showcase-quarkus-eventsourcing/src/main/resources/application.properties
@@ -31,7 +31,7 @@ quarkus.flyway.locations=db/command/common,db/command/h2,db/query/common,db/quer
 
 # H2 in-memory as default database e.g. for flyway
 quarkus.datasource.db-kind=h2
-quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
+quarkus.datasource.jdbc.url=jdbc:h2:tcp://${H2_HOST:localhost}/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
 quarkus.datasource.jdbc.min-size=2
@@ -40,16 +40,16 @@ quarkus.datasource.jdbc.transactions=xa
 
 # PostgreSql as default database e.g. for flyway (for quarkus.profile=postges)
 %postgres.quarkus.datasource.db-kind=postgresql
-%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
+%postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/postgres?stringtype=unspecified
 %postgres.quarkus.datasource.username=postgres
-%postgres.quarkus.datasource.password=
+%postgres.quarkus.datasource.password=postgres
 %postgres.quarkus.datasource.jdbc.max-size=8
 %postgres.quarkus.datasource.jdbc.min-size=2
 %postgres.quarkus.datasource.jdbc.transactions=xa
 
 # H2 in-memory as messaging database 
 quarkus.datasource.messaging.db-kind=h2
-quarkus.datasource.messaging.jdbc.url=jdbc:h2:tcp://localhost/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
+quarkus.datasource.messaging.jdbc.url=jdbc:h2:tcp://${H2_HOST:localhost}/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
 quarkus.datasource.messaging.username=sa
 quarkus.datasource.messaging.password=sa
 quarkus.datasource.messaging.jdbc.min-size=2
@@ -58,9 +58,9 @@ quarkus.datasource.messaging.jdbc.transactions=xa
 
 # PostgreSql as messaging database (for quarkus.profile=postges)
 %postgres.quarkus.datasource.messaging.db-kind=postgresql
-%postgres.quarkus.datasource.messaging.jdbc.url=jdbc:postgresql://localhost:5432/postgres?stringtype=unspecified
+%postgres.quarkus.datasource.messaging.jdbc.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/postgres?stringtype=unspecified
 %postgres.quarkus.datasource.messaging.username=postgres
-%postgres.quarkus.datasource.messaging.password=
+%postgres.quarkus.datasource.messaging.password=postgres
 %postgres.quarkus.datasource.messaging.jdbc.min-size=2
 %postgres.quarkus.datasource.messaging.jdbc.max-size=8
 %postgres.quarkus.datasource.messaging.jdbc.transactions=xa

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/command/h2/V2.0.0__RenameTimestampToEventtimestamp.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/command/h2/V2.0.0__RenameTimestampToEventtimestamp.sql
@@ -1,0 +1,3 @@
+-- Rename the column named "TIMESTAMP" to "EVENTTIMESTAMP" so that there is no conflict with reserved words.
+ALTER TABLE "axon_on_microprofile_tryout"."domainevententry" ALTER COLUMN "TIMESTAMP" RENAME TO "EVENTTIMESTAMP";
+ALTER TABLE "axon_on_microprofile_tryout"."snapshotevententry" ALTER COLUMN "TIMESTAMP" RENAME TO "EVENTTIMESTAMP";

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/command/postgresql/V2.0.0__PostgreSqlRenameTimestampToEventtimestamp.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/command/postgresql/V2.0.0__PostgreSqlRenameTimestampToEventtimestamp.sql
@@ -1,0 +1,3 @@
+-- Rename the column named "TIMESTAMP" to "EVENTTIMESTAMP" so that there is no conflict with reserved words.
+ALTER TABLE "axon_on_microprofile_tryout"."domainevententry" RENAME COLUMN TIMESTAMP TO EVENTTIMESTAMP;
+ALTER TABLE "axon_on_microprofile_tryout"."snapshotevententry" RENAME COLUMN TIMESTAMP TO EVENTTIMESTAMP;

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/query/h2/V2.0.1__H2RenameTimestampToEventtimestamp.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/query/h2/V2.0.1__H2RenameTimestampToEventtimestamp.sql
@@ -1,0 +1,2 @@
+-- Rename the column named "TIMESTAMP" to "EVENTTIMESTAMP" so that there is no conflict with reserved words.
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "timestamp" RENAME TO "eventtimestamp";

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/query/h2/V2.0.2__H2UpperCaseColumnNames.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/query/h2/V2.0.2__H2UpperCaseColumnNames.sql
@@ -1,0 +1,6 @@
+-- Use upper case column names
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "processorName" RENAME TO "PROCESSORNAME";
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "segment" RENAME TO "SEGMENT";
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "tokenType" RENAME TO "TOKENTYPE";
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "eventtimestamp" RENAME TO "EVENTTIMESTAMP";
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" ALTER COLUMN "owner" RENAME TO "OWNER";

--- a/showcase-quarkus-eventsourcing/src/main/resources/db/query/postgresql/V2.0.1__PostgreSqlRenameTimestampToEventtimestamp.sql
+++ b/showcase-quarkus-eventsourcing/src/main/resources/db/query/postgresql/V2.0.1__PostgreSqlRenameTimestampToEventtimestamp.sql
@@ -1,0 +1,2 @@
+-- Rename the column named "TIMESTAMP" to "EVENTTIMESTAMP" so that there is no conflict with reserved words.
+ALTER TABLE "axon_on_microprofile_query_tryout"."tokenentry" RENAME COLUMN "timestamp" TO "eventtimestamp";


### PR DESCRIPTION
### Changes

#### Migration to H2 version 2.1
As documented in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.9 and more detailed in http://www.h2database.com/html/migration-to-v2.html there are some migration steps necessary to update H2 to its new major version 2.

- Rename database columns from "timestamp" to "eventtimestamp" to avoid conflicts with reserved words
- Use quotes for case-sensitive database schema names
- Document additional command line parameter "-ifNotExists" for local H2 database start
- Use upper-case column names for H2

#### Continuous Integration Workflow for PostgeSQL
- Add new workflow to build and test with PostgreSQL database based on [Creating PostgreSQL service containers](https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers)
- Use PhantomJS 2.1.1 that supports linux, since the new workflow runs within a linux docker container
- Provide configurable database hostname and port via environment variables to connect to docker PostgreSQL service instead of localhost.

#### Update Code Coverage for tests
- Update dependency org.jacoco:jacoco-maven-plugin to v0.8.8
- Change `<phase>test</phase>` to `<phase>post-integration-test</phase>` in pom.xml for `jacoco-check` execution, so that all tests are included as before and branch coverage limit is met