### PR TITLE
Automatically update GraalVM Community Edition to newest version

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -28,7 +28,7 @@ jobs:
     env: 
       CI_COMMIT_MESSAGE: Automated native image agent results (CI)
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} Continuous Integration
-      GRAALVM_VERSION: 22.1.0
+      GRAALVM_VERSION: 22.2.0
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v3

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
     ":automergeDigest",
+    ":automergePatch",
     ":automergeRequireAllStatusChecks",
     "group:recommended"
   ],
@@ -15,6 +16,19 @@
       ],
       "groupName": "Quarkus"
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "^(workflow-templates|\\.github\/workflows)\\/[^/]+\\.ya?ml$",
+        "(^|\\/)action\\.ya?ml$]"
+      ],
+      "matchStrings": [
+        "GRAALVM_VERSION:\\s+?(?<currentValue>.*?)\\s+"
+      ],
+      "depNameTemplate": "graalvm/graalvm-ce-builds",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?m?-?(?<version>.*?)$"
+    }
   ]
-  
 }

--- a/showcase-quarkus-eventsourcing/CHANGELOG.md
+++ b/showcase-quarkus-eventsourcing/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+  - Migrate to Java 17 and GraalVM 21.1.0
+  ([#113](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/113))
+  [2022-10-14]
   - Update dependency se.bjurr.gitchangelog:git-changelog-maven-plugin to v1.95.2
   ([#112](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/112))
   [2022-10-10]

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -504,7 +504,7 @@
 			</activation>
 			<properties>
         		<quarkus.package.type>native</quarkus.package.type>
-        		<quarkus.native.additional-build-args>--allow-incomplete-classpath,-H:ReflectionConfigurationFiles=${project.basedir}/reflection-config.json,-H:ResourceConfigurationFiles=${project.basedir}/resources-config.json</quarkus.native.additional-build-args>
+        		<quarkus.native.additional-build-args>-H:ReflectionConfigurationFiles=${project.basedir}/reflection-config.json,-H:ResourceConfigurationFiles=${project.basedir}/resources-config.json,--initialize-at-run-time=com.thoughtworks.xstream.converters.extended.DynamicProxyConverter$Reflections</quarkus.native.additional-build-args>
      		</properties>
 			<build>
 				<plugins>


### PR DESCRIPTION
### Changes:
- [Update to GraalVM Community Edition 22.2.0](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/80/commits/4f580d987ae3466cac6d616636b77b9d2293291f)
- [Configure Renovate to update GraalVM version in GitHub Action](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/80/commits/06789916a51ef6ee955e21906a3f2cc16db3b03c)

With [GraalVM Community Edition 22.2.0](https://github.com/graalvm/graalvm-ce-builds/releases/tag/vm-22.2.0) it is now possible to build a native image for MacOS M1 (aarch64) 🚀.