### PR TITLE
Migrate to Java 17 and GraalVM 21.1.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -65,8 +65,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -74,10 +74,15 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: 17
+        cache: 'maven'
+    - name: Build with Maven
+      working-directory: showcase-quarkus-eventsourcing
+      run: mvn -B package --file pom.xml
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11]
+        java: [17]
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['java11']
+        java: ['java17']
     env: 
       CI_COMMIT_MESSAGE: Automated native image agent results (CI)
       CI_COMMIT_AUTHOR: ${{ github.event.repository.name }} Continuous Integration
-      GRAALVM_VERSION: 22.0.0.2
+      GRAALVM_VERSION: 22.1.0
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
         run: cp target/native-image-agent-trace.json ${{ env.native-image-agent-results-directory }}
       - name: Copy the native image agent configuration files into the native image agent results directory
         working-directory: showcase-quarkus-eventsourcing
-        run: cp target/native-image-agent-trace-configs/* ${{ env.native-image-agent-results-directory }}
+        run: cp --recursive target/native-image-agent-trace-configs/* ${{ env.native-image-agent-results-directory }}
       
       # Upload the native image agent results in case they are needed for troubleshooting for a couple of days
       - name: Archive native image agent results

--- a/showcase-quarkus-eventsourcing/CHANGELOG.md
+++ b/showcase-quarkus-eventsourcing/CHANGELOG.md
@@ -1,3 +1,97 @@
+## Unreleased
+  - Update dependency se.bjurr.gitchangelog:git-changelog-maven-plugin to v1.95.2
+  ([#112](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/112))
+  [2022-10-10]
+  - Update Quarkus to v2.13.1.Final
+  ([#110](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/110))
+  [2022-10-06]
+  - Update axon.version to v4.6.1
+  ([#111](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/111))
+  [2022-10-06]
+  - Update dependency com.tngtech.archunit:archunit-junit5 to v1
+  ([#109](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/109))
+  [2022-10-04]
+  - Update Quarkus to v2.13.0.Final
+  ([#108](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/108))
+  [2022-10-03]
+  - Update dependency se.bjurr.gitchangelog:git-changelog-maven-plugin to v1.94.0
+  ([#107](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/107))
+  [2022-09-27]
+  - Update Quarkus to v2.12.2.Final
+  ([#106](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/106))
+  [2022-09-18]
+  - Update axon.version to v4.6.0
+  ([#105](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/105))
+  [2022-09-16]
+  - Update dependency io.projectreactor:reactor-core to v3.4.23
+  ([#104](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/104))
+  [2022-09-16]
+  - Update Quarkus to v2.12.1.Final
+  ([#103](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/103))
+  [2022-09-12]
+  - Update dependency io.quarkus:quarkus-universe-bom to v2.12.0.Final
+  ([#102](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/102))
+  [2022-09-05]
+  - Update Quarkus
+  ([#101](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/101))
+  [2022-08-29]
+  - Update dependency org.apache.maven.plugins:maven-project-info-reports-plugin to v3.4.1
+  ([#100](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/100))
+  [2022-08-15]
+  - Update dependency io.projectreactor:reactor-core to v3.4.22
+  ([#99](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/99))
+  [2022-08-15]
+  - Update dependency maven to v3.8.6
+  ([#98](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/98))
+  [2022-08-08]
+  - Update dependency org.apache.maven.plugins:maven-site-plugin to v3.12.1
+  ([#97](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/97))
+  [2022-08-05]
+  - Update Quarkus to v2.11.2.Final
+  ([#96](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/96))
+  [2022-08-05]
+  - Update axon.version to v4.5.15
+  ([#95](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/95))
+  [2022-08-03]
+  - Update dependency nl.jqno.equalsverifier:equalsverifier to v3.10.1
+  ([#94](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/94))
+  [2022-08-01]
+  - Update Quarkus to v2.11.1.Final
+  ([#93](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/93))
+  [2022-08-01]
+  - Update dependency org.apache.maven.plugins:maven-project-info-reports-plugin to v3.4.0
+  ([#92](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/92))
+  [2022-07-25]
+  - Update Quarkus
+  ([#91](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/91))
+  [2022-07-25]
+  - Update axon.version to v4.5.14
+  ([#89](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/89))
+  [2022-07-18]
+  - Update dependency io.projectreactor:reactor-core to v3.4.21
+  ([#90](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/90))
+  [2022-07-18]
+  - Update Quarkus to v2.10.2.Final
+  ([#88](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/88))
+  [2022-07-06]
+  - Update Quarkus
+  ([#87](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/87))
+  [2022-06-29]
+  - Update axon.version to v4.5.12
+  ([#86](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/86))
+  [2022-06-27]
+  - Update dependency io.quarkus:quarkus-maven-plugin to v2.10.0.Final
+  ([#85](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/85))
+  [2022-06-20]
+  - Update axon.version to v4.5.10
+  ([#84](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/84))
+  [2022-06-06]
+  - Update Quarkus to v2.9.2.Final
+  ([#83](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/83))
+  [2022-05-30]
+  - Drop unnecessary sequence table in database schema (issue #81)
+  ([#82](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/82))
+  [2022-05-28]
 ## v1.6.0
   - Migrate to H2 version 2.1, Automate PostgreSQL build and test, Update Code Coverage
   ([#79](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/79))

--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -10,8 +10,8 @@
 	<properties>
     	<compiler-plugin.version>3.10.1</compiler-plugin.version>
     	<maven.compiler.parameters>true</maven.compiler.parameters>
-    	<maven.compiler.source>11</maven.compiler.source>
-    	<maven.compiler.target>11</maven.compiler.target>
+    	<maven.compiler.source>17</maven.compiler.source>
+    	<maven.compiler.target>17</maven.compiler.target>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		
@@ -29,7 +29,7 @@
 		<quarkus.plugin.version>2.13.1.Final</quarkus.plugin.version>
 		
 		<axon.version>4.6.1</axon.version>
-		<dom4j.version>1.6.1</dom4j.version>
+		<dom4j.version>2.1.3</dom4j.version>
 		<xom.version>1.2.10</xom.version>
 		<reactor-core.version>3.4.23</reactor-core.version>
 
@@ -93,6 +93,12 @@
 					<artifactId>xml-apis</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+    		<groupId>org.dom4j</groupId>
+    		<artifactId>dom4j</artifactId>
+    		<version>${dom4j.version}</version>
+    		<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/showcase-quarkus-eventsourcing/reflection-config.json
+++ b/showcase-quarkus-eventsourcing/reflection-config.json
@@ -214,6 +214,14 @@
 		"allDeclaredMethods": true
 	},
 	{
+		"name": "org.axonframework.serialization.xml.Dom4JToByteArrayConverter",
+		"allDeclaredMethods": true
+	},
+	{
+		"name": "org.axonframework.serialization.xml.InputStreamToDom4jConverter",
+		"allDeclaredMethods": true
+	},
+	{
 		"name": "org.axonframework.config.MessageHandlerRegistrar",
 		"allDeclaredMethods": true
 	},
@@ -420,12 +428,6 @@
 		"allDeclaredConstructors": true
 	},
 	{
-		"name": "org.axonframework.commandhandling.InterceptorChainParameterResolverFactory",
-		"allDeclaredFields": true,
-		"allDeclaredMethods": true,
-		"allDeclaredConstructors": true
-	},
-	{
 		"name": "org.axonframework.eventhandling.ConcludesBatchParameterResolverFactory",
 		"allDeclaredFields": true,
 		"allDeclaredMethods": true,
@@ -469,6 +471,12 @@
 	},
 	{
 		"name": "org.axonframework.messaging.annotation.SourceIdParameterResolverFactory",
+		"allDeclaredFields": true,
+		"allDeclaredMethods": true,
+		"allDeclaredConstructors": true
+	},
+	{
+		"name": "org.axonframework.messaging.annotation.InterceptorChainParameterResolverFactory",
 		"allDeclaredFields": true,
 		"allDeclaredMethods": true,
 		"allDeclaredConstructors": true


### PR DESCRIPTION
### Changes:
- [migrate to Java 17 and GraalVM 22.1.0](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/113/commits/66cc660b2a09312da4452df8dff54155dc6f31af)
- [fix native image build warnings](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/113/commits/cc7d8f2eed3746ddc91224004fd3e98d07e16366)