### PR TITLE
Optimize configuration

### DIFF
--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -63,19 +63,19 @@
 		<!-- Axon - CQRS and EventSourcing Framework -->
 		<dependency>
 			<groupId>org.axonframework</groupId>
-			<artifactId>axon-configuration-jakarta</artifactId>
+			<artifactId>axon-configuration</artifactId>
 			<version>${axon.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.axonframework</groupId>
-			<artifactId>axon-modelling-jakarta</artifactId>
+			<artifactId>axon-modelling</artifactId>
 			<version>${axon.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.axonframework</groupId>
-			<artifactId>axon-messaging-jakarta</artifactId>
+			<artifactId>axon-messaging</artifactId>
 			<version>${axon.version}</version>
 			<scope>compile</scope>
 		</dependency>

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
@@ -101,8 +101,10 @@ public class AxonConfiguration {
 
     @PostConstruct
     protected void startUp() {
-        Configurer configurer = DefaultConfigurer.defaultConfiguration();
-        configureEventProcessing(configurer);
+    	// autoLocateConfigurerModule doesn't work with quarkus dev mode.
+    	// For more details see application.properties
+		Configurer configurer = DefaultConfigurer.defaultConfiguration(false);
+		configureEventProcessing(configurer);
         addDiscoveredComponentsTo(configurer);
         configuration = configurer
                 .registerComponent(RevisionResolver.class, config -> new AnnotationEventRevisionResolver())
@@ -134,7 +136,7 @@ public class AxonConfiguration {
      * @return {@link ParameterResolverFactory}
      */
     private ParameterResolverFactory parameterResolvers(Configuration config) {
-        Configuration defaultConfig = DefaultConfigurer.defaultConfiguration().buildConfiguration();
+        Configuration defaultConfig = DefaultConfigurer.defaultConfiguration(false).buildConfiguration();
         List<ParameterResolverFactory> factories = allFactoriesOf(defaultConfig.getComponent(ParameterResolverFactory.class));
         factories.add(new CdiParameterResolverFactory()); // add with lowest priority (without using an annotation)
         factories.removeIf(factory -> factory.getClass().getName().contains(".test.")); // remove test factories

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/AxonConfiguration.java
@@ -37,6 +37,7 @@ import org.axonframework.eventsourcing.eventstore.jdbc.EventSchema;
 import org.axonframework.eventsourcing.eventstore.jdbc.JdbcEventStorageEngine;
 import org.axonframework.messaging.annotation.MultiParameterResolverFactory;
 import org.axonframework.messaging.annotation.ParameterResolverFactory;
+import org.axonframework.serialization.AnnotationRevisionResolver;
 import org.axonframework.serialization.RevisionResolver;
 import org.axonframework.serialization.Serializer;
 
@@ -189,13 +190,13 @@ public class AxonConfiguration {
 
     private Serializer flexibleSerializer(Configuration config) {
         return postgreSqlJsonbTypeConverter(JsonbSerializer.fieldAccess())
-                .revisionResolver(config.getComponent(RevisionResolver.class))
+                .revisionResolver(config.getComponent(RevisionResolver.class, AnnotationRevisionResolver::new))
                 .build();
     }
 
     private Serializer messageSerializer(Configuration config) {
         return postgreSqlJsonbTypeConverter(JsonbSerializer.defaultSerializer())
-                .revisionResolver(config.getComponent(RevisionResolver.class))
+                .revisionResolver(config.getComponent(RevisionResolver.class, AnnotationRevisionResolver::new))
                 .build();
     }
 

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/inject/cdi/AxonComponentDiscovery.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/inject/cdi/AxonComponentDiscovery.java
@@ -31,9 +31,13 @@ import org.axonframework.serialization.upcasting.event.EventUpcaster;
 @ApplicationScoped
 public class AxonComponentDiscovery {
 
-    @Inject
-    BeanManager beanManager;
+    private final BeanManager beanManager;
 
+    @Inject
+    public AxonComponentDiscovery(BeanManager beanManager) {
+    	this.beanManager = beanManager;
+    }
+    
     /**
      * Attaches all discovered components to the given {@link AxonComponentDiscoveryContext#getConfigurer()}.
      * 
@@ -121,4 +125,10 @@ public class AxonComponentDiscovery {
         private static final long serialVersionUID = 1L;
         public static final AnnotationLiteral<Any> ANY = new AnnotationLiteralAny();
     }
+
+	@Override
+	public String toString() {
+		return "AxonComponentDiscovery [beanManager=" + beanManager + "]";
+	}
+	
 }

--- a/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/serializer/jsonb/axon/JsonbSerializer.java
+++ b/showcase-quarkus-eventsourcing/src/main/java/io/github/joht/showcase/quarkuseventsourcing/messaging/infrastructure/axon/serializer/jsonb/axon/JsonbSerializer.java
@@ -2,7 +2,6 @@ package io.github.joht.showcase.quarkuseventsourcing.messaging.infrastructure.ax
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import jakarta.json.bind.JsonbBuilder;
 import jakarta.json.bind.JsonbConfig;
@@ -204,7 +203,7 @@ public class JsonbSerializer implements Serializer {
          * @param converter {@link Converter}
          * @return {@link Builder}
          */
-        public Builder converter(Converter converter) {
+        protected Builder converter(Converter converter) {
             this.serializer.converter = converter;
             return this;
         }
@@ -235,20 +234,6 @@ public class JsonbSerializer implements Serializer {
             return this;
         }
 
-        /**
-         * Registers additional chained {@link ContentTypeConverter}s. Requires the default {@link ChainingConverter}.
-         * 
-         * @param contentTypeConverters {@link Class} of a {@link ContentTypeConverter}
-         * @return {@link Builder}
-         * @throws IllegalArgumentException when the default {@link ChainingConverter} had been exchanged by using
-         *             {@link #converter(Converter)}.
-         */
-        @SafeVarargs
-        public final Builder addContentTypeConverters(Class<? extends ContentTypeConverter<?, ?>>... contentTypeConverters) {
-            Stream.of(contentTypeConverters).forEach(this::addContentTypeConverter);
-            return this;
-        }
-
         private ChainingConverter mandatoryChainingConverter() {
             if (this.serializer.getConverter() instanceof ChainingConverter) {
                 return ((ChainingConverter) this.serializer.getConverter());
@@ -263,7 +248,9 @@ public class JsonbSerializer implements Serializer {
          * @return {@link Builder}
          */
         public Builder revisionResolver(RevisionResolver revisionResolver) {
-            this.serializer.revisionResolver = revisionResolver;
+            if (revisionResolver != null) {
+            	this.serializer.revisionResolver = revisionResolver;
+            }
             return this;
         }
 

--- a/showcase-quarkus-eventsourcing/src/main/resources/application.properties
+++ b/showcase-quarkus-eventsourcing/src/main/resources/application.properties
@@ -51,22 +51,32 @@ quarkus.flyway.locations=db/command/common,db/command/h2,db/query/common,db/quer
 #   PostgreSql as database for the command-side and H2 as database for the query-side:
 #quarkus.flyway.locations=db/command/common,db/command/postgresql,db/query/common,db/query/h2
 
+# When enabling XA transactions for a datasource it is recommended to also
+# enable transaction recovery by setting quarkus.transaction-manager.enable-recovery=true, 
+# otherwise data may be lost if the application is terminated abruptly.
+quarkus.transaction-manager.enable-recovery=true
+%postgres.quarkus.transaction-manager.enable-recovery=true
+
 # H2 in-memory as default database e.g. for flyway
 quarkus.datasource.db-kind=h2
 quarkus.datasource.jdbc.url=jdbc:h2:tcp://${H2_HOST:localhost}/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
 quarkus.datasource.username=sa
 quarkus.datasource.password=sa
+quarkus.datasource.jdbc.initial-size=2
 quarkus.datasource.jdbc.min-size=2
 quarkus.datasource.jdbc.max-size=8
 quarkus.datasource.jdbc.transactions=xa
+quarkus.transaction-manager.enable-recovery=true
+
 
 # PostgreSql as default database e.g. for flyway (for quarkus.profile=postges)
 %postgres.quarkus.datasource.db-kind=postgresql
 %postgres.quarkus.datasource.jdbc.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/postgres?stringtype=unspecified
 %postgres.quarkus.datasource.username=postgres
 %postgres.quarkus.datasource.password=postgres
-%postgres.quarkus.datasource.jdbc.max-size=8
+%postgres.quarkus.datasource.jdbc.initial-size=2
 %postgres.quarkus.datasource.jdbc.min-size=2
+%postgres.quarkus.datasource.jdbc.max-size=8
 %postgres.quarkus.datasource.jdbc.transactions=xa
 
 # H2 in-memory as messaging database 
@@ -74,6 +84,7 @@ quarkus.datasource.messaging.db-kind=h2
 quarkus.datasource.messaging.jdbc.url=jdbc:h2:tcp://${H2_HOST:localhost}/mem:eventsourcing;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;DATABASE_TO_UPPER=false
 quarkus.datasource.messaging.username=sa
 quarkus.datasource.messaging.password=sa
+quarkus.datasource.messaging.jdbc.initial-size=2
 quarkus.datasource.messaging.jdbc.min-size=2
 quarkus.datasource.messaging.jdbc.max-size=8
 quarkus.datasource.messaging.jdbc.transactions=xa
@@ -83,6 +94,7 @@ quarkus.datasource.messaging.jdbc.transactions=xa
 %postgres.quarkus.datasource.messaging.jdbc.url=jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/postgres?stringtype=unspecified
 %postgres.quarkus.datasource.messaging.username=postgres
 %postgres.quarkus.datasource.messaging.password=postgres
+%postgres.quarkus.datasource.messaging.jdbc.initial-size=2
 %postgres.quarkus.datasource.messaging.jdbc.min-size=2
 %postgres.quarkus.datasource.messaging.jdbc.max-size=8
 %postgres.quarkus.datasource.messaging.jdbc.transactions=xa

--- a/showcase-quarkus-eventsourcing/src/main/resources/application.properties
+++ b/showcase-quarkus-eventsourcing/src/main/resources/application.properties
@@ -15,6 +15,28 @@ quarkus.jacoco.title=Showcase Quarkus Event Sourcing
 # Graceful shutdown for 3 seconds
 quarkus.shutdown.timeout=3
 
+# Note: Failed Classloading configuration attempt for ServiceLoader in quarkus dev mode
+# 
+# When the Java "ServiceLoader" is used for example 
+# to get all implementations of the ConfigurerModule or ParameterResolverFactory interfaces,
+# it can't find the custom implementation when quarkus dev mode is used.
+#
+# When "Thread.currentThread().getContextClassLoader()" is used as a ClassLoader, 
+# "ServiceLoader" would work as expected. This is also the default when no ClassLoader is specified.
+# Within Jakarta EE / Microprofile applications this is a quite common way to get the ClassLoader,
+# but needs to be used judiciously:
+# https://stackoverflow.com/questions/1771679/difference-between-threads-context-class-loader-and-normal-classloader
+# 
+# Parent first fails if not all dependent artefacts are given and then doesn't resolve the problem.
+#
+# quarkus.class-loading.parent-first-artifacts=org.axonframework:axon-modelling,org.axonframework:axon-eventsourcing,org.axonframework:axon-messaging,org.axonframework:axon-configuration
+#
+# Defining "axon-configuration" as reloadable actually works for the ServiceLoader that loads ConfigurerModule implementations.
+# However, as soon as other artifacts are defined, wired NoClassDefFound exceptions are thrown.
+#
+# quarkus.class-loading.reloadable-artifacts=org.axonframework:axon-configuration
+
+
 # Flyway database setup base settings
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.connect-retries=3

--- a/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/infrastructure/CrossOriginResourceSharingFilterTest.java
+++ b/showcase-quarkus-eventsourcing/src/test/java/io/github/joht/showcase/quarkuseventsourcing/service/infrastructure/CrossOriginResourceSharingFilterTest.java
@@ -1,0 +1,190 @@
+package io.github.joht.showcase.quarkuseventsourcing.service.infrastructure;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+class CrossOriginResourceSharingFilterTest {
+
+	@Mock
+	Instance<Boolean> cors;
+
+	@Mock	
+	Instance<String> allowOrigin;
+
+	@Mock
+	Instance<String> allowCredentials;
+
+	@Mock
+	Instance<String> allowMethods;
+
+	@Mock
+	Instance<String> allowHeaders;
+
+	@Mock
+	Instance<String> exposeHeaders;
+
+	@Mock
+	ContainerRequestContext request;
+	
+	@Mock
+	ContainerResponseContext response;
+	
+	@Mock
+	MultivaluedMap<String, Object> responseHeaders;
+	
+	@InjectMocks
+	CrossOriginResourceSharingFilter filterUnderTest;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		when(response.getHeaders()).thenReturn(responseHeaders);
+	}
+
+	@Test
+	@DisplayName("Do nothing if no CORS configuration is available")
+	void noCorsConfigAvailable() {
+		when(cors.isUnsatisfied()).thenReturn(Boolean.TRUE);
+		
+		filterUnderTest.filter(request, response);
+		
+		verifyNoMoreInteractions(request, response);
+	}
+
+	@Test
+	@DisplayName("Do nothing if 'rest.cors'=null")
+	void corstConfigNull() {
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(null);
+		
+		filterUnderTest.filter(request, response);
+		
+		verifyNoMoreInteractions(request, response);
+	}
+
+	@Test
+	@DisplayName("Do nothing if 'rest.cors'=false")
+	void corstConfigFalse() {
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.FALSE);
+		
+		filterUnderTest.filter(request, response);
+		
+		verifyNoMoreInteractions(request, response);
+	}
+
+	@Test
+	@DisplayName("Do nothing if 'rest.cors'=true but no headers are configured")
+	void corsWithoutHeadersActivated() {
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(response).getHeaders();
+		verifyNoMoreInteractions(request, response);
+	}
+
+	@Test
+	@DisplayName("skip Access-Control-Allow-Credentials if 'rest.cors.allow.origin'=null")
+	void corsAllowCredentialsConfiguredButNull() {
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(allowCredentials.isResolvable()).thenReturn(Boolean.TRUE);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(response).getHeaders();
+		verifyNoMoreInteractions(request, response);
+	}
+	
+	@Test
+	@DisplayName("add Access-Control-Allow-Origin if 'rest.cors.allow.origin' configured")
+	void corsAllowOriginConfigured() {
+		String expectedValue = "http://127.0.0.1:5500";
+		
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(allowOrigin.isResolvable()).thenReturn(Boolean.TRUE);
+		when(allowOrigin.get()).thenReturn(expectedValue);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(responseHeaders).add("Access-Control-Allow-Origin", expectedValue);
+	}
+	
+	@Test
+	@DisplayName("add Access-Control-Allow-Credentials if 'rest.cors.allow.credentials' configured")
+	void corsAllowCredentialsConfigured() {
+		String expectedValue = "true";
+		
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(allowCredentials.isResolvable()).thenReturn(Boolean.TRUE);
+		when(allowCredentials.get()).thenReturn(expectedValue);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(responseHeaders).add("Access-Control-Allow-Credentials", expectedValue);
+	}
+	
+	@Test
+	@DisplayName("add Access-Control-Allow-Methods if 'rest.cors.allow.methods' configured")
+	void corsAllowMethodsConfigured() {
+		String expectedValue = "GET,PUT,POST,DELETE,OPTIONS,HEAD";
+		
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(allowMethods.isResolvable()).thenReturn(Boolean.TRUE);
+		when(allowMethods.get()).thenReturn(expectedValue);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(responseHeaders).add("Access-Control-Allow-Methods", expectedValue);
+	}
+
+	
+	@Test
+	@DisplayName("add Access-Control-Allow-Headers if 'rest.cors.allow.headers' configured")
+	void corsAllowHeadersConfigured() {
+		String expectedValue = "Origin,Authorization,Location,Content-Type";
+		
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(allowHeaders.isResolvable()).thenReturn(Boolean.TRUE);
+		when(allowHeaders.get()).thenReturn(expectedValue);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(responseHeaders).add("Access-Control-Allow-Headers", expectedValue);
+	}
+	
+	@Test
+	@DisplayName("add Access-Control-Expose-Headers if 'rest.cors.expose.headers' configured")
+	void corsExposeHeadersConfigured() {
+		String expectedValue = "Origin,Authorization,Location,Content-Type";
+		
+		when(cors.isResolvable()).thenReturn(Boolean.TRUE);
+		when(cors.get()).thenReturn(Boolean.TRUE);
+		when(exposeHeaders.isResolvable()).thenReturn(Boolean.TRUE);
+		when(exposeHeaders.get()).thenReturn(expectedValue);
+		
+		filterUnderTest.filter(request, response);
+		
+		verify(responseHeaders).add("Access-Control-Expose-Headers", expectedValue);
+	}
+	
+}


### PR DESCRIPTION
### Changes:

- [Use AnnotationRevisionResolver as default for serialization](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/9bcdd5f0fcb880fccb55566fd140a71b72e0734f)
- [Use constructor injection to support programmatic dependency lookup](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/df03a8ef8babc55fa723a658155d8581fc797b3a)
- [Document failed class loading configuration attempt for ServiceLoader](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/2bb7888f7f22ee4a83be33fc6d75e63aa2622deb)
- [Disable autoLocateConfigurerModule](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/08f363f197877356233ee91c458c8d7b77e23074)
- [Add recommended configs for transaction recovery and initial jdbc size](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/f857157cb52489e23cfac3e90b669dbc3d0c3fd4)
- [Switch back to non jakarta axon artifacts](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/6da9353ad3ed1b87e233a431cde2450cd9498435), since they aren't needed when JDBC is used instead of JPA and they provide no source files.
- [Fix warnings to use Instance to inject a ConfigProperty in a Provider](https://github.com/JohT/showcase-quarkus-eventsourcing/pull/131/commits/947098ba936a329ae705f0364c487054988e039a)
See https://github.com/quarkusio/quarkus/issues/27487