### PR TITLE
Update to quarkus version 3.2.0.CR1 breaks native image trace agent

### DIFF
--- a/showcase-quarkus-eventsourcing/pom.xml
+++ b/showcase-quarkus-eventsourcing/pom.xml
@@ -25,8 +25,8 @@
 
    		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     	<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-		<quarkus.platform.version>3.6.3</quarkus.platform.version>
-		<quarkus.plugin.version>3.6.4</quarkus.plugin.version>
+		<quarkus.platform.version>3.2.0.CR1</quarkus.platform.version>
+		<quarkus.plugin.version>3.2.0.CR1</quarkus.plugin.version>
 		<jacc-api.version>1.6.1</jacc-api.version>
 		
 		<axon.version>4.9.1</axon.version>


### PR DESCRIPTION
## Reproduce native image agent trace corrupt json

After running `mvn verify --activate-profiles native-image-agent-trace` locally or in the [pipeline](https://github.com/JohT/showcase-quarkus-eventsourcing/blob/44f1d61d4157e5831f2bda0cc90509f3512afe3d/.github/workflows/native-image.yml#L69) as configured in [pom.xml](https://github.com/JohT/showcase-quarkus-eventsourcing/blob/bbef07bb88ea5bf8d689aa0248ffd1716cd358f9/showcase-quarkus-eventsourcing/pom.xml#L600), the generated JSON is corrupt (not closed correctly) and the very last lines look e.g. like this:

```json
{"caller_class":"java.lang.invoke.InnerClassLambdaMetafactory$1", "args":[], "function":"getDeclaredConstructors", "tracer":"reflect", "class":"io.smallrye.openapi.api.OpenApiConfig$$Lambda$1757/0x00000008014abf70"},
{"caller_class":"java.lang.invoke.InnerClassLambdaMetafactory", "result":"true", "args":[[]], "declaring_class":"io.smallrye.openapi.api.OpenApiConfig$$Lambda$1757/0x00000008014abf70", "function":"invokeConstructor", "tracer":"reflect", "class":"io.smallrye.openapi.api.OpenApiConfig$$Lambda$1757/0x00000008014abf70"},
{"caller_class":"java.lang.invoke.InnerClassLambdaMetafactory$1", "args":[], "function":"getDeclaredConstructors", "tracer":"reflect", "class":"io.smallrye.openapi.api.OpenApiConfig$$Lambda$1758/0x00000008014ac190"},
{"caller_class":"java.lang.invoke.InnerClassLambdaMetafactory", "result":"true", "args":[[]], "declaring_class":"io.smallrye.openapi.api.OpenApiConfig$$Lambda$1758/0x00000008014ac190", "function":"invokeConstructor", "tracer":"reflect", "class":"io.smallrye.openapi.api.OpenApiConfig$$L
```

Trying to process the corrupt JSON file locally with `$GRAALVM_HOME/bin/native-image-configure generate --trace-input=target/native-image-agent-trace.json` or in the [pipeline](https://github.com/JohT/showcase-quarkus-eventsourcing/blob/44f1d61d4157e5831f2bda0cc90509f3512afe3d/.github/workflows/native-image.yml#L72) leads to an error like this:

```
com.oracle.svm.core.util.json.JSONParserException: line 23493 column 286 Missing close quote
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.json.JSONParser.error(JSONParser.java:377)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.json.JSONParser.parseString(JSONParser.java:221)
```

I suspect that the JVM for testing is shutdown without waiting for files to be flushed or something like that. But that's just an idea. Don't know if this could be....

Everything is working fine with quarkus 3.1.3.Final. The change seems to had been introduced with 3.2.0.CR1:
https://github.com/quarkusio/quarkus/compare/3.1.3.Final...3.2.0.CR1

## References

- [Collect Metadata with the Tracing Agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection)
- [Add an option to run integration tests using graalVM native agent](https://github.com/quarkusio/quarkus/issues/27641)
- [Native Image Tracing Agent shutdown before file flush](https://github.com/quarkusio/quarkus/issues/37792)